### PR TITLE
Fixed typo in circle method

### DIFF
--- a/lib/rghost/ps_facade.rb
+++ b/lib/rghost/ps_facade.rb
@@ -238,7 +238,7 @@ class RGhost::PsFacade < RGhost::PsObject
   end
   
   #A facade for the class Circle
-  def circle(option={})
+  def circle(options={})
     set RGhost::Circle.new(options)
   end
 

--- a/rghost.gemspec
+++ b/rghost.gemspec
@@ -5,7 +5,7 @@ require 'rubygems'
 
 spec = Gem::Specification.new do |s|
   s.name      = "rghost"
-  s.version = "0.8.7.3"
+  s.version = "0.8.7.4"
   s.author    = "Shairon Toledo"
   s.email     = "shairon.toledo@gmail.com"
   s.homepage = "http://rghost.rubyforge.org"


### PR DESCRIPTION
-  def circle(option={})
-  def circle(options={})

options was missing the s, causing an error
