### PR TITLE
Fixed output filename for multipage that including more than one ".".

### DIFF
--- a/lib/rghost/ruby_ghost_engine.rb
+++ b/lib/rghost/ruby_ghost_engine.rb
@@ -33,7 +33,7 @@ class RGhost::Engine
     file_err="#{tmp_filename}.rgerr"
 
     multipage=@options[:multipage]
-    file_out.gsub!(/\./,"_%04d.") if multipage
+    file_out.gsub!(/^(.*)\./,'\1_%04d.') if multipage
 
     params=RGhost::Config::GS[:default_params].dup #default parameters gs engine
     params << @document.additional_params.join(" ") unless @options[:convert]


### PR DESCRIPTION
Hi,

Thank you for developing rghost.
This helps me a lot.
So, I send a bug report and pull request.

When invoke RGhost::Convert#to with :filename including multiple dots like this: "sample.1.2.3.jpg".
rghost generates like this output filename "sample_%04d.1_%04d.2_%04d.3_%04d.jpg".
Then failed to convert.

So fixed following line in lib/rghost/ruby_ghost_engine.rb:

<pre>
-     file_out.gsub!(/\./,"_%04d.") if multipage
+     file_out.gsub!(/^(.*)\./,'\1_%04d.') if multipage
</pre>


A minimum reproducible case is:

``` ruby
# % gs --version
# => 8.71

require 'rghost'
rg = RGhost::Convert.new("../sample.1.2.3.pdf")
jpegs = rg.to(:jpeg, :multipage => true, :filename => "../sample.1.2.3.jpg", :debug => true)
# => GPL Ghostscript 9.02: Unrecoverable error, exit code 1
# => /opt/local/bin/gs  -dNOPAUSE -dBATCH -dQUIET -dNOPAGEPROMPT -I/path/to/rghost/lib/rghost/ps -I -sDEVICE=jpeg -sstdout=../sample.1.2.3.jpg.rgerr -sOutputFile=_%04d._%04d./sample_%04d.1_%04d.2_%04d.3_%04d.jpg ../sample.1.2.3.pdf
```
