### PR TITLE
Added % to shellescape regex for multipage support.

### DIFF
--- a/lib/rghost/ruby_ghost_engine.rb
+++ b/lib/rghost/ruby_ghost_engine.rb
@@ -161,7 +161,7 @@ class RGhost::Engine
 
     # Process as a single byte sequence because not all shell
     # implementations are multibyte aware.
-    str.gsub!(/([^A-Za-z0-9_\-.,:\/@\n])/n, "\\\\\\1")
+    str.gsub!(/([^A-Za-z0-9_\-.,:\/@%\n])/n, "\\\\\\1")
 
     # A LF cannot be escaped with a backslash because a backslash + LF
     # combo is regarded as line continuation and simply ignored.


### PR DESCRIPTION
shellescape was adding an extra slash when there was a % in the file name. Multiple page file names include a formatting string such as '%04d'.
