### PR TITLE
Make charset conversion work with ruby 2.0

### DIFF
--- a/lib/rghost/ruby_ghost_config.rb
+++ b/lib/rghost/ruby_ghost_config.rb
@@ -70,11 +70,11 @@ module RGhost::Config
     :stack_elements => 5000,
     :font_encoding => :IsoLatin,
     :charset_convert => begin
-      if RUBY_VERSION =~ /^1.9/
-        lambda { |text| text.encode('ISO-8859-1', 'UTF-8') }
-      else
+      if RUBY_VERSION =~ /^1.8/
         require 'iconv'
         lambda { |text| Iconv::iconv('latin1','utf-8', text).join }
+      else
+        lambda { |text| text.encode('ISO-8859-1', 'UTF-8') }
       end
     end,
     :external_encoding => nil,


### PR DESCRIPTION
I'm assuming nothing below 1.8 is supported.
