### PR TITLE
render_stream method ignoring render errors

### DIFF
--- a/lib/rghost/document.rb
+++ b/lib/rghost/document.rb
@@ -256,6 +256,9 @@ class RGhost::Document < RGhost::PsFacade
   # printer.close
   def render_stream(device,options={})
     rg=render(device,options)
+
+    raise "Error rendering: #{rg.errors}" if rg.errors
+
     out=rg.output.readlines.join
     rg.clear_output
     out


### PR DESCRIPTION
Hi, I'm with a problem on my production enviroment.

I receive the error without any explanation: 
NoMethodError (private method `readlines' called for nil:NilClass):
  app/admin/invoice_items.rb:63:in`gen_boleto'

Looking on the code of RGhost, I found a problem on method render_stream. That ignores the possible errors ocurred on render method, and call rg.output when thats nil. It results in a nightmare error... :)

As a quick fix, I raised the errors if RGhost has errors.
