### PR TITLE
Changed parameter order to support PDF/A

### DIFF
--- a/lib/rghost/ruby_ghost_engine.rb
+++ b/lib/rghost/ruby_ghost_engine.rb
@@ -50,8 +50,8 @@ class RGhost::Engine
       params << "-dLastPage=#{@options[:range].last}"
     end
     params << "-sstdout=#{shellescape(file_err)}"
-    params << @options[:raw] if @options[:raw]
     params << "-sOutputFile=#{shellescape(file_out)}"
+    params << @options[:raw] if @options[:raw]
 
 
     case @document


### PR DESCRIPTION
When using Ghostscript for generating PDF/A-files, the absolute path to "PDFA_def.ps" must be included just before the path to the input-file (as seen in http://ghostscript.com/doc/current/Ps2pdf.htm#PDFA). I have changed the order of parameters to allow this to be defined using the :raw-parameter.
