### PR TITLE
Support for Numeric font sizes

### DIFF
--- a/lib/rghost/font.rb
+++ b/lib/rghost/font.rb
@@ -36,7 +36,7 @@ class RGhost::Font < RGhost::PsObject #:nodoc:
     str_ret+=case size
     when Hash then   "/#{@name} findfont [ #{size[:width]} 0 0 #{size[:height]} 0 0] makefont setfont "
     when Array then  "/#{@name} findfont [ #{size[0]} 0 0 #{size[1]} 0 0] makefont setfont "
-    when Fixnum then "/#{@name} findfont #{size} scalefont setfont "
+    when Numeric then "/#{@name} findfont #{size} scalefont setfont "
     end
     str_ret
   end


### PR DESCRIPTION
I needed to support floating point font sizes. So I made a quick change to use Numeric rather than Fixnum.

This allows you to specify a font size for example such as 6 or 6.5. It works great for me and I thought it might be useful for others.
