### PR TITLE
RGhost::Config.config_platform fails when used on jruby platform

### DIFF
--- a/lib/rghost/ruby_ghost_config.rb
+++ b/lib/rghost/ruby_ghost_config.rb
@@ -84,14 +84,14 @@ module RGhost::Config
   }
 
   def self.config_platform #:nodoc:
-    const = 'PLATFORM'
-    const = "RUBY_"+const if RUBY_VERSION =~ /1\.[89]|2\.\d/
-    GS[:path]=case Object.const_get(const)
-    when /linux/ then "/usr/bin/gs"
-    when /darwin|freebsd|bsd/ then "/usr/local/bin/gs"
-    when /mswin/ then "C:\\gs\\bin\\gswin32\\gswin32c.exe"
-    end
-    not_found_msg="\nGhostscript not found in your environment.\nInstall it and set the variable RGhost::Config::GS[:path] with the executable.\nExample: RGhost::Config::GS[:path]='/path/to/my/gs' #unix-style\n RGhost::Config::GS[:path]=\"C:\\\\gs\\\\bin\\\\gswin32c.exe\"  #windows-style\n"
+    require 'rbconfig'
+    GS[:path]=case RbConfig::CONFIG['host_os']
+                when /linux/ then '/usr/bin/gs'
+                when /mac|darwin|freebsd|bsd/ then '/usr/local/bin/gs'
+                when /mswin|mingw/ then 'C:\\gs\\bin\\gswin32\\gswin32c.exe'
+                else ''
+              end
+    not_found_msg="\nGhostscript not found in your system environment (#{RbConfig::CONFIG['host_os']}).\nInstall it and set the variable RGhost::Config::GS[:path] with the executable.\nExample: RGhost::Config::GS[:path]='/path/to/my/gs' #unix-style\n RGhost::Config::GS[:path]=\"C:\\\\gs\\\\bin\\\\gswin32c.exe\"  #windows-style\n"
     raise not_found_msg unless (File.exists? GS[:path])
   end
 

--- a/spec/rghost_config_spec.rb
+++ b/spec/rghost_config_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe RGhost::Config do
+
+  it 'should detect linux env properly' do
+    RbConfig::CONFIG.should_receive(:[]).twice.with('host_os').and_return('linux')
+    File.should_receive(:exists?).with('/usr/bin/gs').and_return(true)
+    RGhost::Config.config_platform
+    RGhost::Config::GS[:path].should == '/usr/bin/gs'
+  end
+
+  it 'should detect windows env properly' do
+    RbConfig::CONFIG.should_receive(:[]).twice.with('host_os').and_return('mswin')
+    File.should_receive(:exists?).with('C:\\gs\\bin\\gswin32\\gswin32c.exe').and_return(true)
+    RGhost::Config.config_platform
+    RGhost::Config::GS[:path].should == 'C:\\gs\\bin\\gswin32\\gswin32c.exe'
+  end
+
+  it 'should detect other env properly' do
+    RbConfig::CONFIG.should_receive(:[]).twice.with('host_os').and_return('darwin')
+    File.should_receive(:exists?).with('/usr/local/bin/gs').and_return(true)
+    RGhost::Config.config_platform
+    RGhost::Config::GS[:path].should == '/usr/local/bin/gs'
+  end
+
+  it 'should raise error if env is unknown' do
+    RbConfig::CONFIG.should_receive(:[]).twice.with('host_os').and_return('android')
+    expect{RGhost::Config.config_platform}.to raise_error(RuntimeError)
+  end
+
+  it 'should raise error if ghost script is not found' do
+    RbConfig::CONFIG.should_receive(:[]).twice.with('host_os').and_return('linux')
+    File.should_receive(:exists?).with('/usr/bin/gs').and_return(false)
+    expect{RGhost::Config.config_platform}.to raise_error(RuntimeError)
+  end
+
+end


### PR DESCRIPTION
Jruby return RUBY_PLATFORM as 'jruby', not an os identifier, so, GS[:path] is nil when File.exists?(GS[:path]) is called, resulting in a unexpected "can't convert nil to string" error.
