### PR TITLE
Raise RuntimeException when try convert from unspported class

### DIFF
--- a/lib/rghost/ruby_ghost_engine.rb
+++ b/lib/rghost/ruby_ghost_engine.rb
@@ -67,6 +67,8 @@ class RGhost::Engine
       #@delete_input=false unless @options[:debug]
     when String
       file_in=@document
+    else
+      raise RuntimeError.new("Cannot convert #{@document.class}. Supported classes are RGhost::Document or File or String.")
     end
 
     params << shellescape(file_in)

--- a/spec/color_spec.rb
+++ b/spec/color_spec.rb
@@ -143,7 +143,7 @@ describe RGhost::Color do
     
     it "should create a color from a hex(html style)" do
       c = RGhost::RGB.new "#ABBACA"
-      c.ps.to_s.should == "0.670588235294118 0.729411764705882 0.792156862745098 setrgbcolor"
+      c.ps.to_s.should == "0.6705882352941176 0.7294117647058823 0.792156862745098 setrgbcolor"
       
       c = RGhost::RGB.new "#FFFFFF"
       c.ps.to_s.should == "1.0 1.0 1.0 setrgbcolor"
@@ -158,7 +158,7 @@ describe RGhost::Color do
       c.ps.to_s.should == "1.0 1.0 0.0 setrgbcolor"
       
       c = RGhost::RGB.new "#334455"
-      c.ps.to_s.should == "0.2 0.266666666666667 0.333333333333333 setrgbcolor"
+      c.ps.to_s.should == "0.2 0.26666666666666666 0.3333333333333333 setrgbcolor"
       
     end
 

--- a/spec/convert_spec.rb
+++ b/spec/convert_spec.rb
@@ -45,6 +45,10 @@ describe RGhost::Convert do
     File.size(file).should_not be(0)
     
   end
+
+  it "should raise exception when initialize with not supported file" do
+    expect{ RGhost::Convert.new(nil).to :jpeg }.to raise_error(/NilClass/)
+  end
   
   
 

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -6,7 +6,7 @@ describe RGhost::Document do
     
     doc = RGhost::Document.new
     r = doc.render :pdf, :filename => RGhost.using_temp_dir("testdoc.pdf")
-    File.exists?(r.output).should be_true
+    File.exists?(r.output).should be true
     
   end
 


### PR DESCRIPTION
I encountered this error message using RGhost.

```ruby
[3] pry(main)> RGhost::Convert.new(nil).to :jpeg
NoMethodError: undefined method `empty?' for nil:NilClass
from /Users/atton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/rghost-141a28abb655/lib/rghost/ruby_ghost_engine.rb:156:in `shellescape'
[5] pry(main)> RGhost::Convert.new(true).to :jpeg
NoMethodError: undefined method `empty?' for nil:NilClass
from /Users/atton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/rghost-141a28abb655/lib/rghost/ruby_ghost_engine.rb:156:in `shellescape'
```

`RGhost::Engine` [checks](https://github.com/shairontoledo/rghost/blob/master/lib/rghost/ruby_ghost_engine.rb#L57) document class when `render` .
However, this case statement not has else block.
So If I try to convert irregular file, class validation is passed and go to crash the program.

I added else block which throw `RuntimeError` with rspec.
and fix rspecs for my ruby version.
I get results like it

```
2 deprecation warnings total                                                                    
                                                                                                
Finished in 0.81987 seconds (files took 0.26971 seconds to load)                                
69 examples, 0 failures  
```


* My environments

```
macOS Sierra 10.12.6 
$ ruby  -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16]
$ rspec --version
RSpec 3.6
  - rspec-core 3.6.0
  - rspec-expectations 3.6.0
  - rspec-mocks 3.6.0
  - rspec-rails 3.6.1
  - rspec-support 3.6.0

```